### PR TITLE
Fixed a bug in Make

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -9,11 +9,11 @@ debug:
 
 archive:
 	gcc -c astring.c
-	ar rcs astring.o 
+	ar rcs astring.a astring.o
 
 archive_debug:
-	gcc -c astring.c -gcc
-	ar rcs astring.o
-	
+	gcc -c astring.c -g
+	ar rcs astring.a astring.o
+
 clean:
 	rm *.o *.a


### PR DESCRIPTION
The makefile was not generating the archive file correctly.  This has been corrected by giving the correct arguments to the ar command. 