### PR TITLE
Fixed a bug with one of the functions.

### DIFF
--- a/src/astring.c
+++ b/src/astring.c
@@ -300,13 +300,14 @@ void sremove_leading_and_trailing_spaces(string ** array) {
 
 	if (string_debugger_flag) printf("Entering the sremove_leading_and_trailing_spaces function.\n");
 
-    int starting_point = 0, ending_point = 0;
+    int starting_point = -1, ending_point = 0;
     for (int i = 0; i < (*array)->current_num_col; ++i) {
-        if (!starting_point && ((*array)->array[i] > 32 && (*array)->array[i] < 127))
+        if (starting_point == -1 && ((*array)->array[i] > 32 && (*array)->array[i] < 127))
             starting_point = i;
         if ((*array)->array[i] > 32 && (*array)->array[i] < 127)
             ending_point = i;
     }
+    
     // I tried the case of just using strncpy to move the content of the string to the beginning of the string but
     // - this causes an issue in valgrind / low level memory. The error is: __strcpy_sse2_unaligned
     char * temp = calloc(((*array)->current_num_col - starting_point) + 1, sizeof(char));

--- a/src/astring.c
+++ b/src/astring.c
@@ -302,6 +302,7 @@ void sremove_leading_and_trailing_spaces(string ** array) {
 
     int starting_point = -1, ending_point = 0;
     for (int i = 0; i < (*array)->current_num_col; ++i) {
+        // This if statment is just suppose to grab the first character and then stop grabbing anymore after. 
         if (starting_point == -1 && ((*array)->array[i] > 32 && (*array)->array[i] < 127))
             starting_point = i;
         if ((*array)->array[i] > 32 && (*array)->array[i] < 127)

--- a/test/astring_tester.c
+++ b/test/astring_tester.c
@@ -155,6 +155,18 @@ int main() {
         printf("Test-%d-2 Failure: The current_num_col in the string structure is %d and should be %d.\n", test_id, cstring->current_num_col, strlen("Aaron Valoroso"));
         return 1;
     }
+
+    sremove_leading_and_trailing_spaces(&cstring);
+    if (strcmp(cstring->array, "Aaron Valoroso")) {
+        printf("Test-%d-3 Failure: The char pointer in the string structure is %s and should be %s.\n", test_id, cstring->array, "Aaron Valoroso");
+        return 1;
+    }
+
+    if (cstring->current_num_col != strlen("Aaron Valoroso")) {
+        printf("Test-%d-4 Failure: The current_num_col in the string structure is %d and should be %d.\n", test_id, cstring->current_num_col, strlen("Aaron Valoroso"));
+        return 1;
+    }    
+
     // This is for the next test.
     stokenize(&cstring, ' ');
 


### PR DESCRIPTION
There was an issue with the removal of leading or trailing spaces function. The function worked correctly when there was an actual space at the beginning of the string, but failed when there was not a space in front of the string. The bug was caused by an expectation that every string that would be passed to the function would have space in the beginning. I was using an if statement that checks a flag that was both zero and that there was some type of letter / number / symbol being evaluated. The issue is that if the first position of the string was a character, then the flag would be set to zero and not stop the if statement from grabbing another character like it was intended. 